### PR TITLE
[feat] Add camera controls based on current phase

### DIFF
--- a/Assets/Scenes/Azul Game Scene.unity
+++ b/Assets/Scenes/Azul Game Scene.unity
@@ -276,7 +276,7 @@ Camera:
     y: 0
     width: 1
     height: 1
-  near clip plane: 20
+  near clip plane: 2
   far clip plane: 100
   field of view: 119
   orthographic: 1
@@ -305,7 +305,7 @@ Transform:
   m_GameObject: {fileID: 330585543}
   serializedVersion: 2
   m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
-  m_LocalPosition: {x: 0, y: 44.6, z: 0}
+  m_LocalPosition: {x: 0, y: 45, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -662,7 +662,6 @@ MonoBehaviour:
     type: 3}
   roundCounterPrefab: {fileID: 5254510402654930809, guid: 5f695cf4e283c4f75a0b61de7ea114cc,
     type: 3}
-  center: {x: 0, y: 1, z: 0}
 --- !u!1 &722696936
 GameObject:
   m_ObjectHideFlags: 0
@@ -1190,6 +1189,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1970053655}
+  - {fileID: 1947652062}
   - {fileID: 184919607}
   - {fileID: 1922603251}
   - {fileID: 1124264410}
@@ -1408,6 +1408,59 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3bc658b933c374c55ad104195ea1505a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &1947652061
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1947652062}
+  - component: {fileID: 1947652063}
+  m_Layer: 0
+  m_Name: Camera Controller
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1947652062
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1947652061}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1372239317}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1947652063
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1947652061}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c8d70e69caabe44728c07cf60e146bbb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  mainCamera: {fileID: 330585545}
+  acquireSettings:
+    offset: {x: 0, y: 45, z: 0}
+    rotation: {x: 0.70710677, y: 0, z: 0, w: 0.70710677}
+    size: 80
+  scoreSettings:
+    offset: {x: 0, y: 45, z: 0}
+    rotation: {x: 0.70710677, y: 0, z: 0, w: 0.70710677}
+    size: 28
 --- !u!1 &1970053654
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Controllers/CameraController.cs
+++ b/Assets/Scripts/Controllers/CameraController.cs
@@ -1,0 +1,60 @@
+using Azul.Model;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace Azul
+{
+    namespace Controller
+    {
+        public class CameraController : MonoBehaviour
+        {
+            [SerializeField] private Camera mainCamera;
+            [SerializeField] private CameraSettings acquireSettings;
+            [SerializeField] private CameraSettings scoreSettings;
+
+            public void SetupGame()
+            {
+                UnityEngine.Debug.Log($"{this.scoreSettings.GetRotation().eulerAngles}");
+
+                // nothing to do here yet
+            }
+
+            public void InitializeListeners()
+            {
+                PlayerController playerController = System.Instance.GetPlayerController();
+                playerController.AddOnPlayerTurnStartListener(this.OnPlayerTurnStart);
+            }
+
+
+            private void OnPlayerTurnStart(OnPlayerTurnStartPayload payload)
+            {
+                UnityEngine.Debug.Log($"Player: {payload.PlayerNumber} / Phase: {payload.Phase}");
+                if (payload.Phase == Phase.SCORE)
+                {
+                    this.FocusOnPlayerBoard(payload.PlayerNumber);
+                }
+                else
+                {
+                    this.FocusOnTable(payload.PlayerNumber);
+                }
+            }
+
+            private void FocusOnPlayerBoard(int playerNumber)
+            {
+                PlayerBoard playerBoard = System.Instance.GetPlayerBoardController().GetPlayerBoard(playerNumber);
+                this.mainCamera.transform.position = this.scoreSettings.GetOffset() + playerBoard.transform.position;
+                this.mainCamera.transform.rotation = Quaternion.Euler(90.0f, 90.0f * (playerNumber), 0);
+                this.mainCamera.orthographicSize = scoreSettings.GetSize();
+            }
+
+            private void FocusOnTable(int playerNumber)
+            {
+                this.mainCamera.transform.SetPositionAndRotation(acquireSettings.GetOffset(), acquireSettings.GetRotation());
+                this.mainCamera.orthographicSize = acquireSettings.GetSize();
+                // should we rotate the camera?
+            }
+
+        }
+    }
+}

--- a/Assets/Scripts/Controllers/CameraController.cs.meta
+++ b/Assets/Scripts/Controllers/CameraController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c8d70e69caabe44728c07cf60e146bbb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Controllers/GameController.cs
+++ b/Assets/Scripts/Controllers/GameController.cs
@@ -12,6 +12,7 @@ namespace Azul
             void Start()
             {
                 BagController bagController = System.Instance.GetBagController();
+                CameraController cameraController = System.Instance.GetCameraController();
                 FactoryController factoryController = System.Instance.GetFactoryController();
                 PlayerController playerController = System.Instance.GetPlayerController();
                 PlayerBoardController playerBoardController = System.Instance.GetPlayerBoardController();
@@ -21,6 +22,7 @@ namespace Azul
                 TableController tableController = System.Instance.GetTableController();
                 TileController tileController = System.Instance.GetTileController();
                 // TODO - this should be triggered by the UI/Player Ready
+                cameraController.SetupGame();
                 tableController.SetupGame();
                 playerBoardController.SetupGame(playerController.GetNumberOfPlayers(), starController);
                 scoreBoardController.SetupGame();
@@ -30,6 +32,7 @@ namespace Azul
                 scoreBoardController.FillSupply(bagController);
                 roundController.SetupGame();
                 // initialize event listeners
+                cameraController.InitializeListeners();
                 factoryController.InitializeListeners();
                 playerController.InitializeListeners();
                 playerBoardController.InitializeListeners();

--- a/Assets/Scripts/Controllers/PlayerBoardController.cs
+++ b/Assets/Scripts/Controllers/PlayerBoardController.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
-using Azul.Layout;
 using Azul.Model;
+using Azul.PlayerBoardEvents;
 using UnityEngine;
+using UnityEngine.Events;
 
 namespace Azul
 {
@@ -23,6 +23,7 @@ namespace Azul
                 {
                     PlayerBoard board = Instantiate(this.playerBoardPrefab).GetComponent<PlayerBoard>();
                     board.gameObject.name = $"Player Board {idx + 1}";
+                    board.SetPlayerNumber(idx);
                     this.CreateStars(board, starController);
                     this.playerBoards.Add(board);
                 }
@@ -52,6 +53,11 @@ namespace Azul
                 return this.playerBoards;
             }
 
+            public PlayerBoard GetPlayerBoard(int playerNumber)
+            {
+                return this.playerBoards[playerNumber];
+            }
+
             public void AddDrawnTiles(int player, List<Tile> tiles)
             {
                 this.playerBoards[player].AddDrawnTiles(tiles);
@@ -66,6 +72,15 @@ namespace Azul
                 this.playerBoards[payload.PlayerNumber].ActivateLight();
             }
 
+            public int GetPlayerWithOneTile()
+            {
+                return this.playerBoards.Find(playerBoard => playerBoard.HasOneTile()).GetPlayerNumber();
+            }
+
+            public void AddOnPlayerAcquiresOneTileListener(UnityAction<OnPlayerAcquireOneTilePayload> listener)
+            {
+                this.playerBoards.ForEach(playerBoard => playerBoard.AddOnAcquireOneTileListener(listener));
+            }
         }
     }
 }

--- a/Assets/Scripts/Controllers/RoundController.cs
+++ b/Assets/Scripts/Controllers/RoundController.cs
@@ -41,6 +41,16 @@ namespace Azul
                 factoryController.AddOnAllFactoriesEmptyListener(this.OnAllFactoriesEmpty);
             }
 
+            public Round GetCurrentRound()
+            {
+                return this.rounds[this.currentRound];
+            }
+
+            public Phase GetCurrentPhase()
+            {
+                return this.GetCurrentRound().GetCurrentPhase();
+            }
+
             private void OnTableTilesAdded(TableController.OnTableTilesAddedPayload arg0)
             {
                 this.tableEmpty = false;

--- a/Assets/Scripts/Controllers/ScoreBoardController.cs
+++ b/Assets/Scripts/Controllers/ScoreBoardController.cs
@@ -1,9 +1,8 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using Azul.Layout;
 using Azul.Model;
-using Unity.VisualScripting;
+using Azul.PlayerBoardEvents;
 using UnityEngine;
 
 namespace Azul
@@ -32,6 +31,8 @@ namespace Azul
             {
                 RoundController roundController = System.Instance.GetRoundController();
                 roundController.AddOnRoundPhaseAcquireListener(this.OnRoundStart);
+                PlayerBoardController playerBoardController = System.Instance.GetPlayerBoardController();
+                playerBoardController.AddOnPlayerAcquiresOneTileListener(this.OnPlayerAcquireOneTile);
             }
 
             private void CreateScoreBoard()
@@ -77,6 +78,11 @@ namespace Azul
             {
                 // TODO - score tracking!
                 UnityEngine.Debug.Log($"Deducting points: {player} loses {points} points");
+            }
+
+            private void OnPlayerAcquireOneTile(OnPlayerAcquireOneTilePayload payload)
+            {
+                this.DeductPoints(payload.PlayerNumber, payload.AcquiredTiles.Count);
             }
 
             private void OnRoundStart(OnRoundPhaseAcquirePayload payload)

--- a/Assets/Scripts/Models/CameraSettings.cs
+++ b/Assets/Scripts/Models/CameraSettings.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Azul
+{
+
+    namespace Model
+    {
+        [Serializable]
+        public class CameraSettings
+        {
+            [SerializeField] private Vector3 offset;
+            [SerializeField] private Quaternion rotation;
+            [SerializeField] private float size;
+
+            public Vector3 GetOffset()
+            {
+                return this.offset;
+            }
+
+            public Quaternion GetRotation()
+            {
+                return this.rotation;
+            }
+
+            public float GetSize()
+            {
+                return this.size;
+            }
+        }
+
+    }
+}

--- a/Assets/Scripts/Models/CameraSettings.cs.meta
+++ b/Assets/Scripts/Models/CameraSettings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e225983472bfd4efdacca9e15ebbefa1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Models/Tile.cs
+++ b/Assets/Scripts/Models/Tile.cs
@@ -32,6 +32,11 @@ namespace Azul
                 }
             }
 
+            public bool IsOneTile()
+            {
+                return this.color == TileColor.ONE;
+            }
+
             public static Tile Create(GameObject tilePrefab, TileColor color)
             {
                 GameObject gameObject = Instantiate(tilePrefab);

--- a/Assets/Scripts/System/System.cs
+++ b/Assets/Scripts/System/System.cs
@@ -12,6 +12,7 @@ namespace Azul
         public static System Instance { get; private set; }
 
         private BagController bagController;
+        private CameraController cameraController;
         private FactoryController factoryController;
         private PlayerBoardController playerBoardController;
         private PlayerController playerController;
@@ -42,6 +43,15 @@ namespace Azul
                 this.bagController = this.GetComponentInChildren<BagController>();
             }
             return this.bagController;
+        }
+
+        public CameraController GetCameraController()
+        {
+            if (null == this.cameraController)
+            {
+                this.cameraController = this.GetComponentInChildren<CameraController>();
+            }
+            return this.cameraController;
         }
 
         public FactoryController GetFactoryController()


### PR DESCRIPTION
- Start the Score round when the last tile is drawn
- Scoring starts with the player that drew the One tile
- Camera moves to the score board of the active player (score mode only)