### PR TITLE
[fix] Adjust drawing rules to prevent drawing of wilds/one tile

### DIFF
--- a/Assets/Scripts/Controllers/SelectableTileHolderController.cs
+++ b/Assets/Scripts/Controllers/SelectableTileHolderController.cs
@@ -68,7 +68,7 @@ namespace Azul
 
             private void OnTileSelect(OnPointerSelectPayload<Tile> payload)
             {
-                if (!this.canAcquire)
+                if (!this.canAcquire || this.hoveredTiles.Count == 0)
                 {
                     return;
                 }
@@ -81,12 +81,32 @@ namespace Azul
             {
                 this.hoveredTiles = new();
                 bool hasHoveredWild = tile.Color == this.wildColor;
-                if (hasHoveredWild)
+                if (tile.IsOneTile())
                 {
-                    hoveredTiles.Add(tile);
+                    // TODO - we might want to change the cursor so you can't
+                    // draw the one tile.
+                }
+                else if (hasHoveredWild)
+                {
+                    bool onlyHasWilds = this.tiles.All(tile => tile.Color == wildColor || tile.Color == TileColor.ONE);
+                    if (onlyHasWilds)
+                    {
+                        hoveredTiles.Add(tile);
+                        Tile oneTile = this.tiles.Find(tile => tile.IsOneTile());
+                        if (oneTile != null)
+                        {
+                            hoveredTiles.Add(oneTile);
+                        }
+                    }
+                    else
+                    {
+                        // TODO - we might want to change the cursor so you can't draw
+                        // just a wild if there are other tile colors present.
+                    }
                 }
                 else if (null != this.tiles)
                 {
+                    bool grabbedWild = false;
                     foreach (Tile currentTile in this.tiles)
                     {
                         if (currentTile.Color == tile.Color)
@@ -97,9 +117,9 @@ namespace Azul
                         {
                             this.hoveredTiles.Add(currentTile);
                         }
-                        else if (currentTile.Color == this.wildColor && !hasHoveredWild)
+                        else if (currentTile.Color == this.wildColor && !grabbedWild)
                         {
-                            hasHoveredWild = true;
+                            grabbedWild = true;
                             this.hoveredTiles.Add(currentTile);
                         }
                     }


### PR DESCRIPTION
closes https://github.com/TimPoliquin/unity-azul-summer-pavillion/issues/23

The player may only draw a wild if the pool ONLY has wilds in it. If the pool also has the One Tile, the player draws the One Tile in addition to one wild.

The player cannot draw just the One Tile.