### PR TITLE
[fix] AI players cannot discard, causing game freeze

### DIFF
--- a/Assets/Scenes/Game Scene.unity
+++ b/Assets/Scenes/Game Scene.unity
@@ -711,6 +711,46 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5988580855681077878, guid: 626613ad6119245528ce3e60213254c5,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5988580855681077878, guid: 626613ad6119245528ce3e60213254c5,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5988580855681077878, guid: 626613ad6119245528ce3e60213254c5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5988580855681077878, guid: 626613ad6119245528ce3e60213254c5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7579419694014879401, guid: 626613ad6119245528ce3e60213254c5,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7579419694014879401, guid: 626613ad6119245528ce3e60213254c5,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7579419694014879401, guid: 626613ad6119245528ce3e60213254c5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7579419694014879401, guid: 626613ad6119245528ce3e60213254c5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 7599278041637642533, guid: 626613ad6119245528ce3e60213254c5,
         type: 3}
       propertyPath: m_Name
@@ -2090,8 +2130,8 @@ MonoBehaviour:
     m_Bottom: 0
   m_ChildAlignment: 2
   m_Spacing: 10
-  m_ChildForceExpandWidth: 1
-  m_ChildForceExpandHeight: 1
+  m_ChildForceExpandWidth: 0
+  m_ChildForceExpandHeight: 0
   m_ChildControlWidth: 0
   m_ChildControlHeight: 0
   m_ChildScaleWidth: 0

--- a/Assets/Scripts/AI/ScoringStrategy.cs
+++ b/Assets/Scripts/AI/ScoringStrategy.cs
@@ -127,6 +127,7 @@ namespace Azul
                 PlayerBoard playerBoard = playerBoardController.GetPlayerBoard(playerNumber);
                 List<TileCount> tileCounts = playerBoard.GetTileCounts();
                 Dictionary<TileColor, int> toDiscard = new();
+                // add all tiles to the discard set
                 foreach (TileCount tileCount in tileCounts)
                 {
                     toDiscard[tileCount.TileColor] = tileCount.Count;
@@ -163,7 +164,7 @@ namespace Azul
                         }
                     }
                 }
-                return new();
+                return toDiscard;
             }
         }
     }

--- a/Assets/Scripts/Controllers/AIPlayerController.cs
+++ b/Assets/Scripts/Controllers/AIPlayerController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using Azul.AI;
@@ -72,6 +73,17 @@ namespace Azul
                 {
                     Dictionary<TileColor, int> discard = this.scoringStrategy.HandleOverflowDiscard(this.playerNumber, payload.TilesAllowed);
                     PlayerBoardController playerBoardController = System.Instance.GetPlayerBoardController();
+                    UnityEngine.Debug.Log($"Player {this.playerNumber} is discarding the following tiles:");
+                    int totalDiscarded = 0;
+                    foreach (KeyValuePair<TileColor, int> discardNum in discard)
+                    {
+                        UnityEngine.Debug.Log($"- {discardNum.Key}: {discardNum.Value}");
+                        totalDiscarded += discardNum.Value;
+                    }
+                    if (totalDiscarded == 0)
+                    {
+                        throw new OverflowException("Failed to discard any tiles!");
+                    }
                     playerBoardController.DiscardTiles(this.playerNumber, discard);
                     PlayerController playerController = System.Instance.GetPlayerController();
                     playerController.EndPlayerScoringTurn();

--- a/Assets/Scripts/Controllers/PlayerUIController.cs
+++ b/Assets/Scripts/Controllers/PlayerUIController.cs
@@ -45,6 +45,7 @@ namespace Azul
                 ScoreBoardController scoreBoardController = System.Instance.GetScoreBoardController();
                 PlayerUI playerUI = System.Instance.GetPrefabFactory().CreatePlayerUI();
                 playerUI.transform.SetParent(this.playerUIContainer.transform);
+                playerUI.transform.localScale = Vector3.one;
                 playerUI.SetPlayer(player);
                 playerUI.SetScore(scoreBoardController.GetPlayerScore(player.GetPlayerNumber()));
                 this.playerUIs.Add(playerUI);


### PR DESCRIPTION
closes https://github.com/TimPoliquin/unity-olympia-festival-of-the-gods/issues/59

Fixed issue where AI players failed to correctly return the tiles intended for discard, resulting in infinite loops/game crashes.

Also fixed scaling issues on some ui elements.