### PR TITLE
[fix] Player can interact with tiles during first AI turn

### DIFF
--- a/Assets/Prefabs/Models/Legacy/Board/Player Board.prefab
+++ b/Assets/Prefabs/Models/Legacy/Board/Player Board.prefab
@@ -154,7 +154,7 @@ Transform:
   m_GameObject: {fileID: 2978454875877238320}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 34.17, y: 0, z: 18}
+  m_LocalPosition: {x: 27, y: 0, z: 20}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -376,7 +376,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 50, y: 1, z: 50}
+  m_LocalScale: {x: 43, y: 1, z: 43}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5234731856542073814}

--- a/Assets/Scenes/Game Scene.unity
+++ b/Assets/Scenes/Game Scene.unity
@@ -920,41 +920,6 @@ MonoBehaviour:
   - color: 6
     material: {fileID: 2100000, guid: aacaa77a8d0b1408989c655e7f4171a3, type: 2}
     tint: {r: 0, g: 0, b: 0, a: 0}
---- !u!1 &646048642
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 646048643}
-  m_Layer: 5
-  m_Name: Reward UI
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &646048643
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 646048642}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 817813553}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &665030963
 GameObject:
   m_ObjectHideFlags: 0
@@ -1461,7 +1426,6 @@ RectTransform:
   - {fileID: 1205466502}
   - {fileID: 419966714}
   - {fileID: 144521112}
-  - {fileID: 646048643}
   - {fileID: 1697834749}
   - {fileID: 1700354425}
   m_Father: {fileID: 0}
@@ -2982,6 +2946,8 @@ MonoBehaviour:
   - Color: 7
     Prefab: {fileID: 4994233739302111860, guid: ad5629696e6bc49fe8b1c2c1d796f93e,
       type: 3}
+  grantRewardTilesUIPrefab: {fileID: 8425940288351448959, guid: cd39908ab718a424fb20935ebf78ce36,
+    type: 3}
   playerUIPrefab: {fileID: 5210913683160451395, guid: f5cd10e549ba84ef980a102fae715f59,
     type: 3}
   scoreTileSelectionPanelUIPrefab: {fileID: 3741744990853243757, guid: b42097cab83b04197a396f841918ab95,
@@ -3078,8 +3044,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 753debfa74176442e853d0bd927859a7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  rewardUI: {fileID: 646048642}
-  prefab: {fileID: 2228543983264894923, guid: 2b793d7140ec443aebcd9d9cd45a38cf, type: 3}
 --- !u!1 &1697834748
 GameObject:
   m_ObjectHideFlags: 0
@@ -3490,7 +3454,7 @@ MonoBehaviour:
     rotation: {x: 0.54829323, y: 0, z: 0, w: 0.8362862}
     size: 38
   scoreSettings:
-    offset: {x: 23.5, y: 45, z: 2.25}
+    offset: {x: 26, y: 45, z: 2.25}
     rotation: {x: 0.70710677, y: 0, z: 0, w: 0.70710677}
     size: 28
   previewSettings:

--- a/Assets/Scripts/Controllers/PointerEventController.cs
+++ b/Assets/Scripts/Controllers/PointerEventController.cs
@@ -36,15 +36,11 @@ namespace Azul
 
             private T target;
 
-            private bool allowEvents = true;
+            private bool allowEvents = false;
 
             void Awake()
             {
                 this.target = this.GetComponent<T>();
-            }
-
-            void Start()
-            {
                 PlayerController playerController = System.Instance.GetPlayerController();
                 playerController.AddOnPlayerTurnStartListener((payload) =>
                 {


### PR DESCRIPTION
closes https://github.com/TimPoliquin/unity-olympia-festival-of-the-gods/issues/75

Also includes minor adjustments to camera position/player board size to prevent obstruction of important game elements during reward/discard.