### PR TITLE
[feat] Animate tile acquisition

### DIFF
--- a/Assets/Prefabs/Models/Altar/Aphrodite Altar.prefab
+++ b/Assets/Prefabs/Models/Altar/Aphrodite Altar.prefab
@@ -114,7 +114,7 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 03ece64568ab84464b5abac07b2046e8,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.05
+      value: -0.066
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 03ece64568ab84464b5abac07b2046e8,
         type: 3}

--- a/Assets/Prefabs/Models/Table/Table.prefab
+++ b/Assets/Prefabs/Models/Table/Table.prefab
@@ -236,7 +236,8 @@ MonoBehaviour:
   factoriesLayout: {fileID: 3089737495418234027}
   scoreBoard: {fileID: 8361112308366185155}
   center: {fileID: 6196003202671131085}
-  centerRadius: 10
+  centerWidth: 25
+  centerDepth: 15
   dropHeight: 5
 --- !u!114 &3317494338426430283
 MonoBehaviour:

--- a/Assets/Scripts/Controllers/PlayerController.cs
+++ b/Assets/Scripts/Controllers/PlayerController.cs
@@ -2,9 +2,12 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using Azul.Controller.TableEvents;
+using Azul.Event;
 using Azul.Model;
 using Azul.PlayerBoardEvents;
 using Azul.PlayerEvents;
+using Azul.Util;
+using Unity.VisualScripting;
 using UnityEngine;
 using UnityEngine.Events;
 
@@ -241,16 +244,21 @@ namespace Azul
                 this.StartTurn();
             }
 
-            private void OnFactoryTilesDrawn(OnFactoryTilesDrawn payload)
+            private void OnFactoryTilesDrawn(EventTracker<OnFactoryTilesDrawn> payload)
             {
-                System.Instance.GetPlayerBoardController().AddDrawnTiles(this.currentPlayer, payload.TilesDrawn);
-                this.NextTurn();
+                this.StartCoroutine(this.OnTilesDrawn(this.currentPlayer, payload.Payload.TilesDrawn, payload.Done));
             }
 
-            private void OnTableTilesDrawn(OnTableTilesDrawnPayload payload)
+            private void OnTableTilesDrawn(EventTracker<OnTableTilesDrawnPayload> payload)
             {
-                System.Instance.GetPlayerBoardController().AddDrawnTiles(this.currentPlayer, payload.Tiles);
+                this.StartCoroutine(this.OnTilesDrawn(this.currentPlayer, payload.Payload.Tiles, payload.Done));
+            }
+
+            private IEnumerator OnTilesDrawn(int playerNumber, List<Tile> tiles, Action Done)
+            {
+                yield return System.Instance.GetPlayerBoardController().AddDrawnTiles(playerNumber, tiles).WaitUntilCompleted();
                 this.NextTurn();
+                Done.Invoke();
             }
 
             private void onPlayerAcquireOneTile(OnPlayerAcquireOneTilePayload payload)

--- a/Assets/Scripts/Controllers/PlayerUIController.cs
+++ b/Assets/Scripts/Controllers/PlayerUIController.cs
@@ -102,6 +102,12 @@ namespace Azul
             {
                 this.playerUIContainer.SetActive(false);
             }
+
+            public Vector3 GetTileCountPosition(int playerNumber, TileColor tileColor)
+            {
+                PlayerUI playerUI = this.playerUIs[playerNumber];
+                return playerUI.GetTileCountPosition(tileColor);
+            }
         }
     }
 }

--- a/Assets/Scripts/Controllers/TileAnimationController.cs
+++ b/Assets/Scripts/Controllers/TileAnimationController.cs
@@ -66,7 +66,10 @@ namespace Azul
                 tile.GetComponentInChildren<Collider>().enabled = true;
                 tile.GetComponentInChildren<Rigidbody>().useGravity = true;
                 this.isAnimating = false;
-                tileMoveConfig.AfterEach.Invoke(tile);
+                if (tileMoveConfig.AfterEach != null)
+                {
+                    tileMoveConfig.AfterEach.Invoke(tile);
+                }
             }
         }
     }

--- a/Assets/Scripts/Controllers/UIController.cs
+++ b/Assets/Scripts/Controllers/UIController.cs
@@ -15,6 +15,7 @@ namespace Azul
             private IconUIFactory iconUIFactory;
             private MilestoneCompletedPanelUIController milestoneCompletedPanelUIController;
             private OverflowTileSelectionUIController overflowTileSelectionUIController;
+            private PlayerUIController playerUIController;
             private ScoreTileSelectionUIController scoreTileSelectionUIController;
             private ScoreTilesPreviewPanelUIController scoreTilesPreviewPanelUIController;
             private SelectRewardUIController selectRewardUIController;
@@ -75,6 +76,14 @@ namespace Azul
                 return this.overflowTileSelectionUIController;
             }
 
+            public PlayerUIController GetPlayerUIController()
+            {
+                if (null == this.playerUIController)
+                {
+                    this.playerUIController = this.GetComponentInChildren<PlayerUIController>();
+                }
+                return this.playerUIController;
+            }
 
             public ScoreTileSelectionUIController GetScoreTileSelectionUIController()
             {

--- a/Assets/Scripts/Event.meta
+++ b/Assets/Scripts/Event.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d493077b6ff11495dab1654e98410bd4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Event/AzulEvent.cs
+++ b/Assets/Scripts/Event/AzulEvent.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Azul.PreviewEvents;
+using UnityEngine;
+using UnityEngine.Events;
+
+
+namespace Azul
+{
+    namespace Event
+    {
+        [Serializable]
+        public class EventTracker<T>
+        {
+            public int Total { get; init; }
+            public int Progress { get; private set; } = 0;
+            public T Payload { get; init; }
+
+            public void Done()
+            {
+                this.Progress++;
+            }
+
+            public bool IsComplete()
+            {
+                return this.Progress == Total;
+            }
+
+            public WaitUntil WaitUntilCompleted()
+            {
+                return new WaitUntil(() => this.Progress == this.Total);
+            }
+        }
+        [Serializable]
+        public class AzulEvent<T>
+        {
+            [SerializeField] private UnityEvent<EventTracker<T>> unityEvent = new();
+            private int registeredListeners = 0;
+
+            public void AddListener(UnityAction<EventTracker<T>> listener)
+            {
+                this.registeredListeners++;
+                this.unityEvent.AddListener(listener);
+            }
+
+            public EventTracker<T> Invoke(T payload)
+            {
+                EventTracker<T> tracker = new()
+                {
+                    Total = this.registeredListeners,
+                    Payload = payload
+                };
+                this.unityEvent.Invoke(tracker);
+                return tracker;
+            }
+
+        }
+    }
+}

--- a/Assets/Scripts/Event/AzulEvent.cs.meta
+++ b/Assets/Scripts/Event/AzulEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2b96a56fe6a684b94a226e7190e402e7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Models/DrawnTilesContainer.cs
+++ b/Assets/Scripts/Models/DrawnTilesContainer.cs
@@ -39,6 +39,7 @@ namespace Azul
             Dictionary<TileColor, List<GameObject>> tilesByColor = new();
             foreach (Tile tile in tiles)
             {
+                tile.gameObject.SetActive(true);
                 if (!tilesByColor.ContainsKey(tile.Color))
                 {
                     tilesByColor.Add(tile.Color, new());

--- a/Assets/Scripts/Models/PlayerUI.cs
+++ b/Assets/Scripts/Models/PlayerUI.cs
@@ -55,6 +55,12 @@ namespace Azul
             {
                 return this.playerNumber;
             }
+
+            public Vector3 GetTileCountPosition(TileColor tileColor)
+            {
+                PlayerTileCountUI playerTileCountUI = this.tileCountsByColor[tileColor];
+                return System.Instance.GetCameraController().GetMainCamera().ScreenToWorldPoint(playerTileCountUI.transform.position);
+            }
         }
     }
 }

--- a/Assets/Scripts/Utils/VectorUtils.cs
+++ b/Assets/Scripts/Utils/VectorUtils.cs
@@ -13,6 +13,11 @@ namespace Azul
             {
                 return new Vector3(Random.Range(-radius, radius), height, Random.Range(-radius, radius));
             }
+
+            public static Vector3 CreateRandomVector3(float width, float height, float depth)
+            {
+                return new Vector3(Random.Range(-width, width), height, Random.Range(-depth, depth));
+            }
         }
     }
 }


### PR DESCRIPTION
closes https://github.com/TimPoliquin/unity-olympia-festival-of-the-gods/issues/94

- Animate moving tiles to the player board/table during the acquisition phase
- Add event handling tracking so initiators can know when event handling has been completed.