### PR TITLE
[fix] Fix game gets stuck in acquire phase

### DIFF
--- a/Assets/Scripts/Controllers/FactoryController.cs
+++ b/Assets/Scripts/Controllers/FactoryController.cs
@@ -32,6 +32,7 @@ namespace Azul
             private AzulEvent<OnFactoryTilesDrawn> onTilesDrawn = new();
             private AzulEvent<OnFactoryTilesDiscarded> onTilesDiscarded = new();
             private UnityEvent onAllFactoriesEmpty = new();
+            private UnityEvent onFactoryDrawComplete = new();
 
             public void SetupGame(int numPlayers)
             {
@@ -73,6 +74,11 @@ namespace Azul
                 this.onTilesDiscarded.AddListener(listener);
             }
 
+            public void AddOnFactoryDrawCompleteListener(UnityAction listener)
+            {
+                this.onFactoryDrawComplete.AddListener(listener);
+            }
+
             private GameObject CreateFactory(string name)
             {
                 Factory factory = Instantiate(this.factoryPrefab).GetComponent<Factory>();
@@ -101,6 +107,7 @@ namespace Azul
                 {
                     this.onAllFactoriesEmpty.Invoke();
                 }
+                this.onFactoryDrawComplete.Invoke();
             }
 
             public void AddOnAllFactoriesEmptyListener(UnityAction listener)

--- a/Assets/Scripts/Controllers/PlayerController.cs
+++ b/Assets/Scripts/Controllers/PlayerController.cs
@@ -60,8 +60,10 @@ namespace Azul
                 roundController.AddOnRoundPhaseScoreListener(this.OnRoundPhaseScoreStart);
                 FactoryController factoryController = System.Instance.GetFactoryController();
                 factoryController.AddOnFactoryTilesDrawnListener(this.OnFactoryTilesDrawn);
+                factoryController.AddOnFactoryDrawCompleteListener(this.OnDrawComplete);
                 TableController tableController = System.Instance.GetTableController();
                 tableController.AddOnTilesDrawnListener(this.OnTableTilesDrawn);
+                tableController.AddOnTableDrawCompleteListener(this.OnDrawComplete);
                 PlayerBoardController playerBoardController = System.Instance.GetPlayerBoardController();
                 playerBoardController.AddOnPlayerAcquiresOneTileListener(this.onPlayerAcquireOneTile);
             }
@@ -256,15 +258,23 @@ namespace Azul
 
             private IEnumerator OnTilesDrawn(int playerNumber, List<Tile> tiles, Action Done)
             {
-                RoundController roundController = System.Instance.GetRoundController();
-                TableController tableController = System.Instance.GetTableController();
-                Phase currentPhase = roundController.GetCurrentPhase();
                 yield return System.Instance.GetPlayerBoardController().AddDrawnTiles(playerNumber, tiles).WaitUntilCompleted();
-                if (currentPhase == Phase.ACQUIRE && !tableController.IsCompletelyEmpty())
-                {
-                    this.NextTurn();
-                }
                 Done.Invoke();
+            }
+
+            private void OnDrawComplete()
+            {
+                if (System.Instance.GetRoundController().IsCurrentPhaseAcquire())
+                {
+                    if (!System.Instance.GetTableController().IsCompletelyEmpty())
+                    {
+                        this.NextTurn();
+                    }
+                    else
+                    {
+                        UnityEngine.Debug.Log("Table is completely empty - let the round controller handle this one!");
+                    }
+                }
             }
 
             private void onPlayerAcquireOneTile(OnPlayerAcquireOneTilePayload payload)

--- a/Assets/Scripts/Controllers/RoundController.cs
+++ b/Assets/Scripts/Controllers/RoundController.cs
@@ -34,9 +34,6 @@ namespace Azul
             [SerializeField] private UnityEvent<OnRoundPhaseScorePayload> onRoundPhaseScore;
             [SerializeField] private UnityEvent<OnAllRoundsCompletePayload> onAllRoundsComplete;
 
-            private bool factoriesEmpty = false;
-            private bool tableEmpty = false;
-
             public void SetupGame()
             {
                 this.rounds = new();
@@ -49,10 +46,9 @@ namespace Azul
             public void InitializeListeners()
             {
                 TableController tableController = System.Instance.GetTableController();
-                tableController.AddOnTilesAddedListener(this.OnTableTilesAdded);
-                tableController.AddOnTableEmptyListener(this.OnTableEmpty);
+                tableController.AddOnTableDrawCompleteListener(this.OnDrawComplete);
                 FactoryController factoryController = System.Instance.GetFactoryController();
-                factoryController.AddOnAllFactoriesEmptyListener(this.OnAllFactoriesEmpty);
+                factoryController.AddOnFactoryDrawCompleteListener(this.OnDrawComplete);
                 PlayerController playerController = System.Instance.GetPlayerController();
                 playerController.AddOnAllPlayersTurnScoreFinished(this.OnAllPlayersScoreTurnFinished);
             }
@@ -106,19 +102,8 @@ namespace Azul
             }
 
 
-            private void OnTableTilesAdded(OnTableTilesAddedPayload arg0)
+            private void OnDrawComplete()
             {
-                this.tableEmpty = false;
-            }
-            private void OnAllFactoriesEmpty()
-            {
-                this.factoriesEmpty = true;
-                this.CheckAcquirePhaseComplete();
-            }
-
-            private void OnTableEmpty()
-            {
-                this.tableEmpty = true;
                 this.CheckAcquirePhaseComplete();
             }
 
@@ -140,8 +125,6 @@ namespace Azul
 
             public void StartRound()
             {
-                this.factoriesEmpty = false;
-                this.tableEmpty = false;
                 if (this.currentRound == 0)
                 {
                     this.onRoundPhasePrepare.Invoke(new OnRoundPhasePreparePayload
@@ -235,9 +218,12 @@ namespace Azul
 
             private void CheckAcquirePhaseComplete()
             {
-                if (this.rounds[this.currentRound].GetCurrentPhase() == Phase.ACQUIRE && this.factoriesEmpty && this.tableEmpty)
+                if (this.IsCurrentPhaseAcquire())
                 {
-                    this.NextPhase();
+                    if (System.Instance.GetTableController().IsCompletelyEmpty())
+                    {
+                        this.NextPhase();
+                    }
                 }
             }
 

--- a/Assets/Scripts/Controllers/TableController.cs
+++ b/Assets/Scripts/Controllers/TableController.cs
@@ -99,6 +99,7 @@ namespace Azul
             private UnityEvent<OnTileHoverEnterPayload> onTilesHoverEnter = new();
             private UnityEvent<OnTileHoverExitPayload> onTilesHoverExit = new();
             private UnityEvent<OnTileSelectPayload> onTilesSelect = new();
+            private UnityEvent onTableDrawComplete = new();
             private UnityEvent onTableEmpty = new();
 
             private Table table;
@@ -160,6 +161,11 @@ namespace Azul
             public void AddOnTableEmptyListener(UnityAction listener)
             {
                 this.onTableEmpty.AddListener(listener);
+            }
+
+            public void AddOnTableDrawCompleteListener(UnityAction listener)
+            {
+                this.onTableDrawComplete.AddListener(listener);
             }
 
             public Factory GetFactoryWithMostTilesOfColor(TileColor desiredColor)
@@ -334,6 +340,7 @@ namespace Azul
                 {
                     this.onTableEmpty.Invoke();
                 }
+                this.onTableDrawComplete.Invoke();
             }
 
             public void AddOnTilesHoverEnterListener(UnityAction<OnTileHoverEnterPayload> listener)


### PR DESCRIPTION
closes https://github.com/TimPoliquin/unity-olympia-festival-of-the-gods/issues/135

The game should no longer get stuck in the acquire phase when the table is empty and a player draws from the last factory.