### PR TITLE
[feat] Hades panel requires manual dismissal

### DIFF
--- a/Assets/Prefabs/UI/Acquiring/Hades Token Panel UI.prefab
+++ b/Assets/Prefabs/UI/Acquiring/Hades Token Panel UI.prefab
@@ -174,7 +174,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 500, y: 200}
+  m_SizeDelta: {x: 500, y: 220}
   m_Pivot: {x: 0.5, y: 0}
 --- !u!225 &4290072566153814402
 CanvasGroup:
@@ -229,6 +229,7 @@ MonoBehaviour:
   hadesIcon: {fileID: 4106860978739752071}
   scoreContainer: {fileID: 3327485810503262452}
   scoreText: {fileID: 8316061098381916882}
+  dismissButton: {fileID: 531438272338308058}
 --- !u!1 &4547543424856989466
 GameObject:
   m_ObjectHideFlags: 0
@@ -585,6 +586,152 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 269594390338335999}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2066842836808122316
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5461721331641884691}
+    m_Modifications:
+    - target: {fileID: 2971251157141829249, guid: c50c24d2ce0af4836ad84b1a5299bae8,
+        type: 3}
+      propertyPath: m_Name
+      value: Dismiss Button
+      objectReference: {fileID: 0}
+    - target: {fileID: 7217325981748162380, guid: c50c24d2ce0af4836ad84b1a5299bae8,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7217325981748162380, guid: c50c24d2ce0af4836ad84b1a5299bae8,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7217325981748162380, guid: c50c24d2ce0af4836ad84b1a5299bae8,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7217325981748162380, guid: c50c24d2ce0af4836ad84b1a5299bae8,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7217325981748162380, guid: c50c24d2ce0af4836ad84b1a5299bae8,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7217325981748162380, guid: c50c24d2ce0af4836ad84b1a5299bae8,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7217325981748162380, guid: c50c24d2ce0af4836ad84b1a5299bae8,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 156.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 7217325981748162380, guid: c50c24d2ce0af4836ad84b1a5299bae8,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 7217325981748162380, guid: c50c24d2ce0af4836ad84b1a5299bae8,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7217325981748162380, guid: c50c24d2ce0af4836ad84b1a5299bae8,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7217325981748162380, guid: c50c24d2ce0af4836ad84b1a5299bae8,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7217325981748162380, guid: c50c24d2ce0af4836ad84b1a5299bae8,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7217325981748162380, guid: c50c24d2ce0af4836ad84b1a5299bae8,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7217325981748162380, guid: c50c24d2ce0af4836ad84b1a5299bae8,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7217325981748162380, guid: c50c24d2ce0af4836ad84b1a5299bae8,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7217325981748162380, guid: c50c24d2ce0af4836ad84b1a5299bae8,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7217325981748162380, guid: c50c24d2ce0af4836ad84b1a5299bae8,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 6.57
+      objectReference: {fileID: 0}
+    - target: {fileID: 7217325981748162380, guid: c50c24d2ce0af4836ad84b1a5299bae8,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7217325981748162380, guid: c50c24d2ce0af4836ad84b1a5299bae8,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7217325981748162380, guid: c50c24d2ce0af4836ad84b1a5299bae8,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7398494408331526473, guid: c50c24d2ce0af4836ad84b1a5299bae8,
+        type: 3}
+      propertyPath: m_Name
+      value: Dismiss
+      objectReference: {fileID: 0}
+    - target: {fileID: 7419239346391299031, guid: c50c24d2ce0af4836ad84b1a5299bae8,
+        type: 3}
+      propertyPath: m_text
+      value: Dismiss
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c50c24d2ce0af4836ad84b1a5299bae8, type: 3}
+--- !u!114 &531438272338308058 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2003797093437117462, guid: c50c24d2ce0af4836ad84b1a5299bae8,
+    type: 3}
+  m_PrefabInstance: {fileID: 2066842836808122316}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &8685175533879283840 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 7217325981748162380, guid: c50c24d2ce0af4836ad84b1a5299bae8,
+    type: 3}
+  m_PrefabInstance: {fileID: 2066842836808122316}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &4209678049785080392
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -837,6 +984,10 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 3657769872599941327, guid: f1672ae5c65924dafa04aaa68e211042,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 8685175533879283840}
     - targetCorrespondingSourceObject: {fileID: 2515373840011873592, guid: f1672ae5c65924dafa04aaa68e211042,
         type: 3}
       insertIndex: -1
@@ -888,9 +1039,9 @@ MonoBehaviour:
   m_Padding:
     m_Left: 0
     m_Right: 0
-    m_Top: 0
+    m_Top: 10
     m_Bottom: 0
-  m_ChildAlignment: 4
+  m_ChildAlignment: 1
   m_Spacing: 10
   m_ChildForceExpandWidth: 0
   m_ChildForceExpandHeight: 0

--- a/Assets/Scripts/Animation/Fade.cs
+++ b/Assets/Scripts/Animation/Fade.cs
@@ -13,6 +13,7 @@ namespace Azul
         {
             private CanvasGroup canvasGroup;
             private bool hidden;
+            private CoroutineResult hiddenResult;
 
             [SerializeField] private float delay;
             [SerializeField] private float time = .25f;
@@ -39,13 +40,20 @@ namespace Azul
 
             public CoroutineResult Hide()
             {
-                CoroutineResult result = CoroutineResult.Single();
+                if (null != this.hiddenResult)
+                {
+                    return this.hiddenResult;
+                }
+                this.hiddenResult = CoroutineResult.Single();
                 this.hidden = true;
-                this.StartCoroutine(this.Transition(0, this.time, 0, result));
-                return result;
+                this.StartCoroutine(this.Transition(0, this.time, 0, this.hiddenResult, () =>
+                {
+                    this.hiddenResult = null;
+                }));
+                return this.hiddenResult;
             }
 
-            private IEnumerator Transition(float delay, float time, float alpha, CoroutineResult result)
+            private IEnumerator Transition(float delay, float time, float alpha, CoroutineResult result, Action callback = null)
             {
                 result.Start();
                 bool hidden = this.hidden;
@@ -57,6 +65,7 @@ namespace Azul
                     yield return null;
                 }
                 result.Finish();
+                callback?.Invoke();
             }
         }
     }

--- a/Assets/Scripts/Controllers/HadesTokenPanelUIController.cs
+++ b/Assets/Scripts/Controllers/HadesTokenPanelUIController.cs
@@ -25,8 +25,17 @@ namespace Azul
                 result.Start();
                 this.hadesSFX.Play();
                 HadesTokenPanelUI panel = System.Instance.GetPrefabFactory().CreateHadesTokenPanelUI();
+                panel.AddOnDismissHandler(() => this.OnDismiss(panel, playerNumber, tileCount, result));
                 yield return panel.Show(tileCount).WaitUntilCompleted();
-                yield return new WaitForSeconds(this.displaySeconds);
+            }
+
+            private void OnDismiss(HadesTokenPanelUI panel, int playerNumber, int tileCount, CoroutineResult result)
+            {
+                this.StartCoroutine(this.OnDismissCoroutine(panel, playerNumber, tileCount, result));
+            }
+
+            private IEnumerator OnDismissCoroutine(HadesTokenPanelUI panel, int playerNumber, int tileCount, CoroutineResult result)
+            {
                 yield return panel.AnimateScoreToPoint(System.Instance.GetUIController().GetPlayerUIController().GetScoreScreenPosition(playerNumber), .5f, this.scoreMoveTime).WaitUntilCompleted();
                 System.Instance.GetScoreBoardController().DeductPoints(playerNumber, tileCount);
                 yield return panel.Hide().WaitUntilCompleted();

--- a/Assets/Scripts/Models/HadesTokenPanelUI.cs
+++ b/Assets/Scripts/Models/HadesTokenPanelUI.cs
@@ -4,6 +4,8 @@ using Azul.Animation;
 using Azul.Util;
 using TMPro;
 using UnityEngine;
+using UnityEngine.Events;
+using UnityEngine.UI;
 
 namespace Azul
 {
@@ -16,14 +18,18 @@ namespace Azul
             [SerializeField] private IconUI hadesIcon;
             [SerializeField] private GameObject scoreContainer;
             [SerializeField] private TextMeshProUGUI scoreText;
+            [SerializeField] private Button dismissButton;
             private Fade fade;
             private MoveAndScale moveAndScale;
+            private UnityEvent onDismiss = new();
 
             void Awake()
             {
                 this.fade = this.GetComponent<Fade>();
                 this.moveAndScale = this.GetComponent<MoveAndScale>();
+                this.dismissButton.onClick.AddListener(this.OnDismiss);
             }
+
             public CoroutineResult Show(int tileCount)
             {
                 this.hadesIcon.SetTileColor(TileColor.ONE);
@@ -40,6 +46,16 @@ namespace Azul
             public CoroutineResult Hide()
             {
                 return this.fade.Hide();
+            }
+
+            private void OnDismiss()
+            {
+                this.onDismiss.Invoke();
+            }
+
+            public void AddOnDismissHandler(UnityAction listener)
+            {
+                this.onDismiss.AddListener(listener);
             }
         }
 


### PR DESCRIPTION
closes https://github.com/TimPoliquin/unity-olympia-festival-of-the-gods/issues/137

Play testing showed that players did not have enough time to read the hades tax panel when acquiring the Hades token. The Hades Tax panel has been updated to require manual dismissal, like all other panels.