### PR TITLE
[fix] Disable altar selection when claiming rewards

### DIFF
--- a/Assets/Scripts/Controllers/AIPlayerController.cs
+++ b/Assets/Scripts/Controllers/AIPlayerController.cs
@@ -174,7 +174,7 @@ namespace Azul
                 for (int idx = 0; idx < numberOfTiles; idx++)
                 {
                     TileColor tileColor = this.scoringStrategy.ChooseReward();
-                    yield return playerBoardController.GrantRewardAndWait(this.playerNumber, tileColor).WaitUntilCompleted();
+                    yield return playerBoardController.ClaimRewardAndWait(this.playerNumber, tileColor).WaitUntilCompleted();
                 }
                 Done();
             }

--- a/Assets/Scripts/Controllers/PlayerBoardController.cs
+++ b/Assets/Scripts/Controllers/PlayerBoardController.cs
@@ -233,6 +233,7 @@ namespace Azul
 
             private void OnPlayerTurnScoringStart(int playerNumber)
             {
+                UnityEngine.Debug.Log($"PlayerTurnScoringStart {playerNumber}");
                 Dictionary<TileColor, int> tileColorCounts = new();
                 PlayerBoard board = this.playerBoards[playerNumber];
                 TileColor wildColor = System.Instance.GetRoundController().GetCurrentRound().GetWildColor();
@@ -261,6 +262,11 @@ namespace Azul
                     space.ActivateHighlight();
                     space.AddOnStarSpaceSelectListener(this.OnPointerSelectSpace);
                 });
+            }
+
+            public void RestoreScoringUI(int playerNumber)
+            {
+                this.OnPlayerTurnScoringStart(playerNumber);
             }
 
             public void HideScoringUI(int playerNumber)
@@ -438,27 +444,27 @@ namespace Azul
                 }
             }
 
-            public Tile GrantReward(int playerNumber, TileColor tileColor)
+            public Tile ClaimReward(int playerNumber, TileColor tileColor)
             {
                 BagController bagController = System.Instance.GetBagController();
-                Tile grantedTile = bagController.Draw(tileColor);
-                this.AddDrawnTiles(playerNumber, new() { grantedTile });
-                return grantedTile;
+                Tile claimedTile = bagController.Draw(tileColor);
+                this.AddDrawnTiles(playerNumber, new() { claimedTile });
+                return claimedTile;
             }
 
-            public CoroutineResultValue<Tile> GrantRewardAndWait(int playerNumber, TileColor tileColor)
+            public CoroutineResultValue<Tile> ClaimRewardAndWait(int playerNumber, TileColor tileColor)
             {
                 CoroutineResultValue<Tile> result = new CoroutineResultValue<Tile>();
-                this.StartCoroutine(this.GrantRewardCoroutine(playerNumber, tileColor, result)); ;
+                this.StartCoroutine(this.ClaimRewardCoroutine(playerNumber, tileColor, result)); ;
                 return result;
             }
 
-            private IEnumerator GrantRewardCoroutine(int playerNumber, TileColor tileColor, CoroutineResultValue<Tile> result)
+            private IEnumerator ClaimRewardCoroutine(int playerNumber, TileColor tileColor, CoroutineResultValue<Tile> result)
             {
                 BagController bagController = System.Instance.GetBagController();
-                Tile grantedTile = bagController.Draw(tileColor);
-                yield return this.AddDrawnTiles(playerNumber, new() { grantedTile }).WaitUntilCompleted();
-                result.Finish(grantedTile);
+                Tile claimedTile = bagController.Draw(tileColor);
+                yield return this.AddDrawnTiles(playerNumber, new() { claimedTile }).WaitUntilCompleted();
+                result.Finish(claimedTile);
             }
 
             public bool IsPlacingTiles()

--- a/Assets/Scripts/Controllers/ScoreTileSelectionUIController.cs
+++ b/Assets/Scripts/Controllers/ScoreTileSelectionUIController.cs
@@ -51,7 +51,7 @@ namespace Azul
                 overflowTileSelectionUIController.AddOnCancelListener(this.OnOverflowSelectionCancel);
                 playerBoardController.AddOnPlayerBoardEarnRewardListener(this.OnEarnReward);
                 SelectRewardUIController selectRewardUIController = System.Instance.GetUIController().GetSelectRewardUIController();
-                selectRewardUIController.AddOnGrantRewardListener(this.OnGrantReward);
+                selectRewardUIController.AddOnClaimRewardListener(this.OnClaimReward);
             }
 
             public bool IsPanelOpen()
@@ -272,7 +272,7 @@ namespace Azul
                 payload.Done();
             }
 
-            private void OnGrantReward(OnGrantRewardPayload payload)
+            private void OnClaimReward(OnClaimRewardPayload payload)
             {
                 this.CleanupScoreSelectionUIElements();
                 if (this.isCurrentPlayerHuman)

--- a/Assets/Scripts/Models/GrantRewardTilesUI.cs
+++ b/Assets/Scripts/Models/GrantRewardTilesUI.cs
@@ -1,6 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
-using Azul.GrantRewardEvents;
+using Azul.ClaimRewardEvents;
 using Azul.Model;
 using Azul.ScoreTileSelectionUIEvent;
 using TMPro;
@@ -10,9 +10,9 @@ using UnityEngine.UI;
 
 namespace Azul
 {
-    namespace GrantRewardEvents
+    namespace ClaimRewardEvents
     {
-        public struct OnGrantTileSelectionConfirmPayload
+        public struct OnClaimTileSelectionConfirmPayload
         {
             public int PlayerNumber { get; init; }
             public List<TileColor> Selections { get; init; }
@@ -33,7 +33,7 @@ namespace Azul
 
             private List<ScoreTileSelectionUI> scoreTileSelectionUIs;
 
-            private UnityEvent<OnGrantTileSelectionConfirmPayload> onGrantTileSelectionConfirm = new();
+            private UnityEvent<OnClaimTileSelectionConfirmPayload> onClaimTileSelectionConfirm = new();
 
             void Awake()
             {
@@ -115,8 +115,8 @@ namespace Azul
                         tileSelections.Add(scoreTileSelectionUI.GetColor());
                     }
                 }
-                this.onGrantTileSelectionConfirm.Invoke(
-                    new OnGrantTileSelectionConfirmPayload
+                this.onClaimTileSelectionConfirm.Invoke(
+                    new OnClaimTileSelectionConfirmPayload
                     {
                         PlayerNumber = this.playerNumber,
                         Selections = tileSelections
@@ -124,9 +124,9 @@ namespace Azul
                 );
             }
 
-            public void AddOnConfirmListener(UnityAction<OnGrantTileSelectionConfirmPayload> listener)
+            public void AddOnConfirmListener(UnityAction<OnClaimTileSelectionConfirmPayload> listener)
             {
-                this.onGrantTileSelectionConfirm.AddListener(listener);
+                this.onClaimTileSelectionConfirm.AddListener(listener);
             }
 
             public void AddScoreTileSelectionUI(ScoreTileSelectionUI ui)


### PR DESCRIPTION
closes https://github.com/TimPoliquin/unity-olympia-festival-of-the-gods/issues/160

Score selection spaces now wait until after a reward is claimed to recalculate.